### PR TITLE
Add current model to home

### DIFF
--- a/frontend/src/components/features/chat/event-content-helpers/get-observation-result.ts
+++ b/frontend/src/components/features/chat/event-content-helpers/get-observation-result.ts
@@ -17,9 +17,19 @@ export const getObservationResult = (event: OpenHandsObservation) => {
     case "run_ipython":
     case "read":
     case "edit":
-    case "mcp":
       if (!hasContent || contentIncludesError) return "error";
-      return "success"; // Content is valid
+      return "success";
+
+    case "mcp":
+      try {
+        const parsed = JSON.parse(event.content);
+        if (typeof parsed?.isError === "boolean") {
+          return parsed.isError ? "error" : "success";
+        }
+      } catch {
+        return hasContent ? "success" : "error";
+      }
+      return hasContent ? "success" : "error";
     default:
       return "success";
   }

--- a/frontend/src/components/features/home/home-header/home-header.tsx
+++ b/frontend/src/components/features/home/home-header/home-header.tsx
@@ -1,11 +1,13 @@
 import { GuideMessage } from "./guide-message";
 import { HomeHeaderTitle } from "./home-header-title";
+import { LlmModelMessage } from "./llm-model-message";
 
 export function HomeHeader() {
   return (
     <header className="flex flex-col items-center gap-12">
       <GuideMessage />
       <HomeHeaderTitle />
+      <LlmModelMessage />
     </header>
   );
 }

--- a/frontend/src/components/features/home/home-header/llm-model-message.tsx
+++ b/frontend/src/components/features/home/home-header/llm-model-message.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router";
+import { Typography } from "#/ui/typography";
+import { useSettings } from "#/hooks/query/use-settings";
+import { DEFAULT_OPENHANDS_MODEL } from "#/utils/verified-models";
+import GearIcon from "#/icons/settings-gear.svg?react";
+
+export function LlmModelMessage() {
+  const { t } = useTranslation();
+  const { data: settings, isLoading } = useSettings();
+
+  // grab the active model (or fall back to default)
+  const currentModel = settings?.LLM_MODEL || DEFAULT_OPENHANDS_MODEL;
+
+  return (
+    <div className="">
+      {!isLoading && (
+        <div className="flex items-center gap-2">
+          <Typography.H1> {t("Current Model")}: </Typography.H1>
+          <div className="flex items-center gap-2 bg-[#454545] text-[#A3A3A3] rounded-sm border border-[#727987] px-3 py-1">
+            <span className="text-white text-xl">{currentModel}</span>
+            <span className="text-white text-2xl flex items-center relative -top-0.5">
+              |
+            </span>
+            <Link to="/settings">
+              <GearIcon
+                width={25}
+                height={25}
+                className="cursor-pointer text-white hover:opacity-80"
+              />
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- [X] This change is worth documenting at https://docs.all-hands.dev/
- [X] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

This change would alter the very first screen the user sees, so it is probably a good idea to update the documentation.

**End-user friendly description of the problem this fixes or functionality this introduces.**
This introduces new functionality that allows the user to see what model they are using before starting a chat. It also links them to the LLM settings for easy access to changing the model.

---
**Summarize what the PR does, explaining any non-trivial design decisions.**
The PR makes a new react component that fetches the current model from the settings and includes it in the home page header. I decided to not let the user change the model in the home page and instead direct them to the settings to not introduce unnecessary complexity.

---
**Link of any specific issues this addresses:**
https://github.com/All-Hands-AI/OpenHands/issues/11088